### PR TITLE
feat: add publishing settings in package.json file

### DIFF
--- a/packages/sso-button-react/package.json
+++ b/packages/sso-button-react/package.json
@@ -1,10 +1,23 @@
 {
   "name": "@nufi/sso-button-react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "NuFi",
   "license": "MIT",
   "private": false,
   "type": "module",
+  "homepage": "https://nu.fi",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nufi-official/nufi-dapp-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nufi-official/nufi-dapp-sdk/issues"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc --p ./tsconfig-build.json && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
@@ -13,7 +26,8 @@
     "prettier:check": "prettier --check .",
     "prettier": "prettier --write .",
     "test:tsc": "yarn tsc --noEmit",
-    "test": "yarn prettier:check && yarn lint && yarn test:tsc"
+    "test": "yarn prettier:check && yarn lint && yarn test:tsc",
+    "prepublishOnly": "rm -rf dist && yarn test && yarn build"
   },
   "peerDependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
Based on https://docs.npmjs.com/creating-and-publishing-an-organization-scoped-package
Package is already published on: https://www.npmjs.com/package/@nufi/sso-button-react?activeTab=readme 

Steps ublishing package:

1. Update version inside `package.json` (required
2. run ```npm publish --access public``` (this will run `prepublishOnly` script automatically)
3. auth via CLI link

